### PR TITLE
FEAT: add optimizations for normalized/non-normlized vectors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,7 +70,7 @@ dependencies = [
 
 [[package]]
 name = "semanticsimilarity_rs"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "num-traits",
  "rayon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "autocfg"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,6 +40,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
 
 [[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "rayon"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,5 +72,6 @@ dependencies = [
 name = "semanticsimilarity_rs"
 version = "0.1.0"
 dependencies = [
+ "num-traits",
  "rayon",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "semanticsimilarity_rs"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "A library designed to compute similarity/distance metrics between embeddings"
 license = "MIT"  

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ license = "MIT"
 
 [dependencies]
 rayon = "1.5.1"
+num-traits = "0.2"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![Crates.io Total Downloads](https://img.shields.io/crates/d/semanticsimilarity_rs)
 ![Crates.io License](https://img.shields.io/crates/l/semanticsimilarity_rs)
 
-A small library designed to compute similarity/dissimilarity metrics between embeddings using vector sdistance. 
+A small library designed to compute similarity/dissimilarity metrics between embeddings using vector  distance. 
 
 Current distance measures implemented:
 - [x] Cosine 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 A small library designed to compute similarity/dissimilarity metrics between embeddings using vector  distance. 
 
 Current distance measures implemented:
-- [x] Cosine 
+- [x] Cosine (handles both normalized and non-normalized vectors)
 - [x] Euclidean
 - [x] Manhattan
 - [x] Chebyshev
@@ -49,7 +49,7 @@ fn main() {
     let vec1: [f64; 3] = [1.0, 2.0, 3.0];
     let vec2: [f64; 3] = [4.0, 5.0, 6.0];
 
-    let similarity = cosine_similarity(&vec1, &vec2);
+    let similarity = cosine_similarity(&vec1, &vec2, false);
 
     println!("Cosine similarity between vec1 and vec2: {}", similarity);
 }

--- a/src/similarity.rs
+++ b/src/similarity.rs
@@ -1,10 +1,16 @@
 use rayon::prelude::*;
 
-pub fn cosine_similarity(vec1: &[f64], vec2: &[f64]) -> f64 {
+// handle both normalized and non-normalized vectors
+pub fn cosine_similarity(vec1: &[f64], vec2: &[f64], normalized: bool) -> f64 {
     let dot_product: f64 = vec1.par_iter().zip(vec2.par_iter()).map(|(a, b)| a * b).sum();
-    let magnitude1: f64 = vec1.par_iter().map(|x| x.powi(2)).sum::<f64>().sqrt();
-    let magnitude2: f64 = vec2.par_iter().map(|x| x.powi(2)).sum::<f64>().sqrt();
-    dot_product / (magnitude1 * magnitude2)
+
+    if normalized {
+        dot_product
+    } else {
+        let magnitude1: f64 = vec1.par_iter().map(|x| x.powi(2)).sum::<f64>().sqrt();
+        let magnitude2: f64 = vec2.par_iter().map(|x| x.powi(2)).sum::<f64>().sqrt();
+        dot_product / (magnitude1 * magnitude2)
+    }
 }
 
 
@@ -45,8 +51,9 @@ pub fn pearson_correlation(vec1: &[f64], vec2: &[f64]) -> f64 {
 }
 
 
-pub fn angular_distance(vec1: &[f64], vec2: &[f64]) -> f64 {
-    let cosine_sim = crate::cosine_similarity(vec1, vec2);
+// angular distance (vec1, vec2, bool)
+pub fn angular_distance(vec1: &[f64], vec2: &[f64], normalized: bool) -> f64 {
+    let cosine_sim = cosine_similarity(vec1, vec2, normalized);
     cosine_sim.acos() / std::f64::consts::PI
 }
 


### PR DESCRIPTION
Related to this issue: https://github.com/maishathasin/SemanticSimilarity-rs/issues/1

# What it does
Adds optimization for cosine similarity to reduce the computation by adding option for normalized or non-normalised vectors 
